### PR TITLE
文字列とDateオブジェクトの比較部分

### DIFF
--- a/autopagerize.user.js
+++ b/autopagerize.user.js
@@ -767,7 +767,7 @@ else {
     var cacheInfo = getCache()
     var xhrStates = {}
     SITEINFO_IMPORT_URLS.forEach(function(i) {
-        if (!cacheInfo[i] || cacheInfo[i].expire < new Date()) {
+        if (!cacheInfo[i] || new Date(cacheInfo[i].expire) < new Date()) {
             var opt = {
                 method: 'get',
                 url: i,


### PR DESCRIPTION
元々Dateオブジェクトだった文字列が自動で型変換されず、キャッシュが自動更新されなくなっていたため修正
