### PR TITLE
変なnextLink対策

### DIFF
--- a/autopagerize.user.js
+++ b/autopagerize.user.js
@@ -104,7 +104,7 @@ var AutoPager = function(info) {
         return
     }
 
-    this.requestURL = url
+    this.requestURL = this.validateURL(url)
     this.loadedURLs = {}
     this.loadedURLs[location.href] = true
     var toggle = function() {self.stateToggle()}
@@ -385,7 +385,7 @@ AutoPager.prototype.requestLoad = function(res) {
     AutoPager.filters.forEach(function(i) {
         i(page)
     })
-    this.requestURL = url
+    this.requestURL = this.validateURL(url)
     this.showLoading(false)
     this.onScroll()
     if (!url) {
@@ -476,7 +476,9 @@ AutoPager.prototype.getNextURL = function(xpath, doc, url) {
         }
     }
 }
-
+AutoPager.prototype.validateURL = function(url) {
+  return url.replace(/(^https?:\/\/(?:[^./?]+\.){1,}[^./?]+)\?/,"$1/\?")
+}
 AutoPager.prototype.terminate = function() {
     window.removeEventListener('scroll', this.scroll, false)
     this.updateIcon('terminated')


### PR DESCRIPTION
http://domain/?param
とあるべきところを、
http://domain?param
になっているnextLinkに対して、
/を挟むことで対応する。
参照：http://userscripts.org/topics/88805
