### PR TITLE
特定サイトでの表示崩れを防止

### DIFF
--- a/autopagerize.user.js
+++ b/autopagerize.user.js
@@ -155,6 +155,7 @@ var AutoPager = function(info) {
         this.initIcon()
         this.initHelp()
         GM_addStyle('@media print{#autopagerize_icon, #autopagerize_help {display: none !important;}}')
+        GM_addStyle('hr.autopagerize_page_separator {clear: both;}')
         this.icon.addEventListener("mouseover", function() {
             self.viewHelp()
         }, true)


### PR DESCRIPTION
hr.autopagerize_page_separatorにclear:bothを付加するようにしました。
具体的にこの対策が有効なページとしては、
http://funa1g.tumblr.com/
http://album.blog.yam.com/j6vu04honda
などがあります。
